### PR TITLE
feat: Add core JSON-RPC protocol definitions

### DIFF
--- a/pkg/protocol/jsonrpc.go
+++ b/pkg/protocol/jsonrpc.go
@@ -1,0 +1,125 @@
+// Package protocol provides the core JSON-RPC protocol types for MCP
+package protocol
+
+// RequestID represents a uniquely identifying ID for a request in JSON-RPC
+// It can be either a string or an integer
+type RequestID interface{}
+
+// Meta represents metadata that can be attached to various objects
+type Meta struct {
+	ProgressToken interface{} `json:"progressToken,omitempty"`
+}
+
+// Message represents the base JSON-RPC message
+type Message struct {
+	JSONRPC string     `json:"jsonrpc"`
+	ID      *RequestID `json:"id,omitempty"`
+}
+
+// Request represents a JSON-RPC request that expects a response
+type Request struct {
+	Message
+	Method string      `json:"method"`
+	Params interface{} `json:"params,omitempty"`
+}
+
+// Response represents a successful JSON-RPC response
+type Response struct {
+	Message
+	Result interface{} `json:"result"`
+}
+
+// Error represents a JSON-RPC error response
+type Error struct {
+	Message
+	Error *ErrorObject `json:"error"`
+}
+
+// ErrorObject contains the error details for a JSON-RPC error response
+type ErrorObject struct {
+	Code    int         `json:"code"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// Notification represents a JSON-RPC notification that does not expect a response
+type Notification struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params,omitempty"`
+}
+
+// Common JSON-RPC error codes
+const (
+	// Standard JSON-RPC 2.0 errors
+	ErrParseError     = -32700
+	ErrInvalidRequest = -32600
+	ErrMethodNotFound = -32601
+	ErrInvalidParams  = -32602
+	ErrInternalError  = -32603
+	
+	// Server error codes are from -32000 to -32099
+	ErrServerNotInitialized = -32002
+	ErrUnknownResource     = -32001
+	ErrInvalidURI          = -32000
+)
+
+// Error message constants
+const (
+	MsgParseError     = "Parse error"
+	MsgInvalidRequest = "Invalid request"
+	MsgMethodNotFound = "Method not found"
+	MsgInvalidParams  = "Invalid params"
+	MsgInternalError  = "Internal error"
+	
+	MsgServerNotInitialized = "Server not initialized"
+	MsgUnknownResource     = "Unknown resource"
+	MsgInvalidURI          = "Invalid URI"
+)
+
+// NewRequest creates a new JSON-RPC request
+func NewRequest(id RequestID, method string, params interface{}) *Request {
+	return &Request{
+		Message: Message{
+			JSONRPC: "2.0",
+			ID:      &id,
+		},
+		Method: method,
+		Params: params,
+	}
+}
+
+// NewResponse creates a new JSON-RPC response
+func NewResponse(id RequestID, result interface{}) *Response {
+	return &Response{
+		Message: Message{
+			JSONRPC: "2.0",
+			ID:      &id,
+		},
+		Result: result,
+	}
+}
+
+// NewError creates a new JSON-RPC error response
+func NewError(id RequestID, code int, message string, data interface{}) *Error {
+	return &Error{
+		Message: Message{
+			JSONRPC: "2.0",
+			ID:      &id,
+		},
+		Error: &ErrorObject{
+			Code:    code,
+			Message: message,
+			Data:    data,
+		},
+	}
+}
+
+// NewNotification creates a new JSON-RPC notification
+func NewNotification(method string, params interface{}) *Notification {
+	return &Notification{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  params,
+	}
+}

--- a/pkg/protocol/jsonrpc_test.go
+++ b/pkg/protocol/jsonrpc_test.go
@@ -1,0 +1,201 @@
+package protocol
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestJSONRPCRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *Request
+		wantErr bool
+	}{
+		{
+			name: "basic request",
+			req: NewRequest("123", "test_method", map[string]string{
+				"param1": "value1",
+			}),
+			wantErr: false,
+		},
+		{
+			name: "request with nil params",
+			req:  NewRequest(1, "test_method", nil),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("json.Marshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err == nil {
+				var got Request
+				err = json.Unmarshal(data, &got)
+				if err != nil {
+					t.Errorf("json.Unmarshal() error = %v", err)
+					return
+				}
+
+				if got.JSONRPC != "2.0" {
+					t.Errorf("JSONRPC version mismatch, got = %v, want = 2.0", got.JSONRPC)
+				}
+
+				if got.Method != tt.req.Method {
+					t.Errorf("Method mismatch, got = %v, want = %v", got.Method, tt.req.Method)
+				}
+			}
+		})
+	}
+}
+
+func TestJSONRPCResponse(t *testing.T) {
+	tests := []struct {
+		name    string
+		resp    *Response
+		wantErr bool
+	}{
+		{
+			name: "basic response",
+			resp: NewResponse("123", map[string]string{
+				"result": "success",
+			}),
+			wantErr: false,
+		},
+		{
+			name: "response with nil result",
+			resp: NewResponse(1, nil),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.resp)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("json.Marshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err == nil {
+				var got Response
+				err = json.Unmarshal(data, &got)
+				if err != nil {
+					t.Errorf("json.Unmarshal() error = %v", err)
+					return
+				}
+
+				if got.JSONRPC != "2.0" {
+					t.Errorf("JSONRPC version mismatch, got = %v, want = 2.0", got.JSONRPC)
+				}
+
+				if !reflect.DeepEqual(got.Result, tt.resp.Result) {
+					t.Errorf("Result mismatch, got = %v, want = %v", got.Result, tt.resp.Result)
+				}
+			}
+		})
+	}
+}
+
+func TestJSONRPCError(t *testing.T) {
+	tests := []struct {
+		name    string
+		err     *Error
+		wantErr bool
+	}{
+		{
+			name: "parse error",
+			err:  NewError("123", ErrParseError, MsgParseError, nil),
+			wantErr: false,
+		},
+		{
+			name: "error with data",
+			err:  NewError(1, ErrInvalidParams, MsgInvalidParams, "Invalid parameter: id"),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.err)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("json.Marshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err == nil {
+				var got Error
+				err = json.Unmarshal(data, &got)
+				if err != nil {
+					t.Errorf("json.Unmarshal() error = %v", err)
+					return
+				}
+
+				if got.JSONRPC != "2.0" {
+					t.Errorf("JSONRPC version mismatch, got = %v, want = 2.0", got.JSONRPC)
+				}
+
+				if got.Error.Code != tt.err.Error.Code {
+					t.Errorf("Error code mismatch, got = %v, want = %v", got.Error.Code, tt.err.Error.Code)
+				}
+
+				if got.Error.Message != tt.err.Error.Message {
+					t.Errorf("Error message mismatch, got = %v, want = %v", got.Error.Message, tt.err.Error.Message)
+				}
+			}
+		})
+	}
+}
+
+func TestJSONRPCNotification(t *testing.T) {
+	tests := []struct {
+		name    string
+		notif   *Notification
+		wantErr bool
+	}{
+		{
+			name: "basic notification",
+			notif: NewNotification("test_notification", map[string]string{
+				"param1": "value1",
+			}),
+			wantErr: false,
+		},
+		{
+			name: "notification with nil params",
+			notif: NewNotification("test_notification", nil),
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.notif)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("json.Marshal() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if err == nil {
+				var got Notification
+				err = json.Unmarshal(data, &got)
+				if err != nil {
+					t.Errorf("json.Unmarshal() error = %v", err)
+					return
+				}
+
+				if got.JSONRPC != "2.0" {
+					t.Errorf("JSONRPC version mismatch, got = %v, want = 2.0", got.JSONRPC)
+				}
+
+				if got.Method != tt.notif.Method {
+					t.Errorf("Method mismatch, got = %v, want = %v", got.Method, tt.notif.Method)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit adds the basic JSON-RPC protocol types for the MCP server implementation:

- Base JSON-RPC message types (Message, Request, Response, Error, Notification)
- Error codes and messages
- Helper functions for creating protocol messages
- Comprehensive test coverage for all message types

The protocol package provides the foundation for handling JSON-RPC 2.0 communication in the MCP server.